### PR TITLE
Feat: Add tag wall with filtering to blog page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -102,7 +102,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.9.tgz",
       "integrity": "sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -2049,7 +2048,6 @@
       "resolved": "https://registry.npmjs.org/@gatsbyjs/reach-router/-/reach-router-2.0.1.tgz",
       "integrity": "sha512-gmSZniS9/phwgEgpFARMpNg21PkYDZEpfgEzvkgpE/iku4uvXqCrxr86fXbTpI9mkrhKS1SCTYmLGe60VdHcdQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "invariant": "^2.2.4",
         "prop-types": "^15.8.1"
@@ -2750,7 +2748,6 @@
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-2.3.0.tgz",
       "integrity": "sha512-zQH//gdOmuu7nt2oJR29vFhDv88oGPmVw6BggmrHeMI+xgEkp1B2dX9/bMBSYtK0dyLX/aOmesKS09g222K1/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0",
         "@types/react": ">=16"
@@ -3087,7 +3084,6 @@
       "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.8.3.tgz",
       "integrity": "sha512-Euf/un4ZAiClnlUXqPB9phQlKbveU+2CotZv7m7i+qkgvFn5nAGnrV4h1OzQU42j9dpgOxWi7AttUDMrvkbhCQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.0",
         "@parcel/cache": "2.8.3",
@@ -4471,6 +4467,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
       "integrity": "sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/experimental-utils": "4.33.0",
         "@typescript-eslint/scope-manager": "4.33.0",
@@ -4503,6 +4500,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
       "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4515,6 +4513,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz",
       "integrity": "sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.7",
         "@typescript-eslint/scope-manager": "4.33.0",
@@ -4539,6 +4538,7 @@
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
       "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eslint-visitor-keys": "^2.0.0"
       },
@@ -4585,6 +4585,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
       "integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "4.33.0",
         "@typescript-eslint/visitor-keys": "4.33.0"
@@ -4602,6 +4603,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
       "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
       },
@@ -4615,6 +4617,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
       "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "4.33.0",
         "@typescript-eslint/visitor-keys": "4.33.0",
@@ -4642,6 +4645,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
       "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4654,6 +4658,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
       "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "4.33.0",
         "eslint-visitor-keys": "^2.0.0"
@@ -4878,7 +4883,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4933,7 +4937,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5483,6 +5486,7 @@
       "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
       "deprecated": "babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "@babel/parser": "^7.7.0",
@@ -5503,6 +5507,7 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
       "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -6017,7 +6022,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -6992,7 +6996,6 @@
       "integrity": "sha512-7vsMc/Lty6AGnn7uFpYT56QesI5D2Y/UkgKounk87OP9Z2H9Z8kj6jzcSGAxFmUtDOS0ntK6lbQz+Nsa0Jj6mQ==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -8442,7 +8445,6 @@
       "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.3",
@@ -8579,7 +8581,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-5.10.0.tgz",
       "integrity": "sha512-vcz32f+7TP+kvTUyMXZmCnNujBQZDNmcqPImw8b9PZ+16w1Qdm6ryRuYZYVaG9xRqqmAPr2Cs9FAX5gN+x/bjw==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.15",
         "string-natural-compare": "^3.0.1"
@@ -8596,7 +8597,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -8651,7 +8651,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
       "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "aria-query": "^5.3.2",
         "array-includes": "^3.1.8",
@@ -8681,7 +8680,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.4.tgz",
       "integrity": "sha512-BGP0jRmfYyvOyvMoRX/uoUeW+GqNj9y16bPQzqAHf3AYII/tDs+jMN0dBVkl88/OZwNGwrVFxE7riHsXVfy/LQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -8714,7 +8712,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
       "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9991,7 +9988,6 @@
       "integrity": "sha512-xumIbDl0bk/Het+9wDQETNSHtkobXaeUQTciwzbT42RW/zIoPkKTjNzdDrWOBzzpmR0RU/qEnLa0udDhzS01Ww==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
         "@babel/core": "^7.20.12",
@@ -10497,7 +10493,6 @@
       "resolved": "https://registry.npmjs.org/gatsby-plugin-sharp/-/gatsby-plugin-sharp-5.14.0.tgz",
       "integrity": "sha512-Kk0hePabeuFI9wJ3a4mhtubpn/7SrALM4YlZJIOvXVYfx2mGv3SIHpAtm0YcLxi+lBKKVUPcA5uh3gNptupDTQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "async": "^3.2.5",
@@ -10701,7 +10696,6 @@
       "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-5.14.0.tgz",
       "integrity": "sha512-uewEJaHvdxZlN6DOtZCIUuI7X5v9MRk5IVpCYy9SIZCDbnUA5siEd2A4SC+kcXxJM6AUbdvkfayqpVJrm5JaZA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "chokidar": "^3.5.3",
@@ -11188,7 +11182,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -11590,7 +11583,6 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.10.0.tgz",
       "integrity": "sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -18208,7 +18200,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
@@ -18899,7 +18890,6 @@
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
       "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -19211,7 +19201,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -19358,7 +19347,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -19384,7 +19372,6 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -19547,7 +19534,6 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
       "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.9.2"
       }
@@ -20795,7 +20781,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -22474,7 +22459,6 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "license": "(MIT OR CC0-1.0)",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -23303,7 +23287,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.98.0.tgz",
       "integrity": "sha512-UFynvx+gM44Gv9qFgj0acCQK2VE1CtdfwFdimkapco3hlPCJ/zeq73n2yVKimVbtm+TnApIugGhLJnkU6gjYXA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "license": "0BSD",
   "scripts": {
     "build": "gatsby build",
-    "develop": "gatsby develop",
+    "develop": "gatsby develop -H 0.0.0.0",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md,css}\"",
     "start": "gatsby develop",
     "serve": "gatsby serve",

--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -483,3 +483,104 @@ a:hover {
     padding-top: 130px;
   }
 }
+
+/* Tag Wall Styles */
+.tag-wall {
+  margin: 2rem 0;
+  background: rgba(255, 255, 255, 0.03);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 24px;
+  padding: 2rem;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+}
+
+.tag-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.tag-btn {
+  background: rgba(249, 115, 22, 0.15);
+  border: 1px solid rgba(249, 115, 22, 0.3);
+  color: #e5e7eb;
+  padding: 0.5rem 1rem;
+  border-radius: 20px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  white-space: nowrap;
+}
+
+.tag-btn:hover {
+  background: rgba(249, 115, 22, 0.25);
+  border-color: rgba(249, 115, 22, 0.5);
+  transform: translateY(-1px);
+  color: #ffffff;
+}
+
+.tag-btn.active {
+  background: linear-gradient(135deg, #f97316, #fb923c, #fbbf24);
+  border-color: #f97316;
+  color: white;
+  box-shadow: 0 2px 12px rgba(249, 115, 22, 0.5);
+}
+
+.show-all-tags-btn {
+  background: transparent;
+  border: 1px dashed rgba(255, 255, 255, 0.3);
+  color: #a0a0b0;
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  margin-top: 0.5rem;
+}
+
+.show-all-tags-btn:hover {
+  border-color: #f97316;
+  color: #e5e7eb;
+  background: rgba(249, 115, 22, 0.1);
+}
+
+.post-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+  margin: 0.5rem 0;
+}
+
+.post-tag {
+  background: rgba(249, 115, 22, 0.1);
+  border: 1px solid rgba(249, 115, 22, 0.2);
+  color: #a0a0b0;
+  padding: 0.25rem 0.625rem;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  transition: all 0.2s ease;
+}
+
+.post-tag:hover {
+  background: rgba(249, 115, 22, 0.2);
+  color: #e5e7eb;
+  border-color: rgba(249, 115, 22, 0.4);
+}
+
+.no-posts {
+  text-align: center;
+  color: #a0a0b0;
+  font-size: 1.125rem;
+  padding: 3rem;
+  background: rgba(255, 255, 255, 0.03);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+}

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -6,6 +6,29 @@ import * as styles from "../components/index.module.css"
 
 const BlogPage = ({ data }) => {
   const posts = data.allMarkdownRemark.nodes
+  const [selectedTag, setSelectedTag] = React.useState(null)
+  const [showAllTags, setShowAllTags] = React.useState(false)
+
+  const tagCounts = React.useMemo(() => {
+    const counts = {}
+    posts.forEach(post => {
+      const tags = post.frontmatter.tags || []
+      tags.forEach(tag => {
+        counts[tag] = (counts[tag] || 0) + 1
+      })
+    })
+    return Object.entries(counts).sort((a, b) => b[1] - a[1])
+  }, [posts])
+
+  const popularTags = tagCounts.filter(([tag, count]) => count >= 2)
+  const displayTags = showAllTags ? tagCounts : popularTags
+
+  const filteredPosts = React.useMemo(() => {
+    if (!selectedTag) return posts
+    return posts.filter(post =>
+      (post.frontmatter.tags || []).includes(selectedTag),
+    )
+  }, [posts, selectedTag])
 
   return (
     <Layout>
@@ -15,8 +38,41 @@ const BlogPage = ({ data }) => {
           Sharing thoughts and experiences about software architecture,
           development practices, and engineering solutions.
         </p>
+
+        {displayTags.length > 0 && (
+          <div className="tag-wall">
+            <div className="tag-filter">
+              <button
+                className={`tag-btn ${!selectedTag ? "active" : ""}`}
+                onClick={() => setSelectedTag(null)}
+              >
+                All Posts
+              </button>
+              {displayTags.map(([tag, count]) => (
+                <button
+                  key={tag}
+                  className={`tag-btn ${selectedTag === tag ? "active" : ""}`}
+                  onClick={() => setSelectedTag(tag)}
+                >
+                  {tag} ({count})
+                </button>
+              ))}
+            </div>
+            {popularTags.length < tagCounts.length && (
+              <button
+                className="show-all-tags-btn"
+                onClick={() => setShowAllTags(!showAllTags)}
+              >
+                {showAllTags
+                  ? "Show fewer tags"
+                  : `Show all tags (${tagCounts.length})`}
+              </button>
+            )}
+          </div>
+        )}
+
         <div className={styles.list}>
-          {posts.map((post, index) => (
+          {filteredPosts.map((post, index) => (
             <Link
               key={post.id}
               to={post.fields?.slug || "#"}
@@ -27,11 +83,23 @@ const BlogPage = ({ data }) => {
                 <span className="blog-link">{post.frontmatter.title}</span>
               </h2>
               <small className="blog-date">{post.frontmatter.date}</small>
+              {post.frontmatter.tags && post.frontmatter.tags.length > 0 && (
+                <div className="post-tags">
+                  {post.frontmatter.tags.map(tag => (
+                    <span key={tag} className="post-tag">
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              )}
               <p className="blog-excerpt">
                 {post.frontmatter.description || post.excerpt}
               </p>
             </Link>
           ))}
+          {filteredPosts.length === 0 && (
+            <p className="no-posts">No posts found with this tag.</p>
+          )}
         </div>
         <div className={styles.textCenter}>
           <Link to="/" className="btn btn-secondary">
@@ -56,6 +124,7 @@ export const query = graphql`
           date(formatString: "MMMM DD, YYYY")
           title
           description
+          tags
         }
       }
     }


### PR DESCRIPTION
## Summary
- Add client-side tag filtering with click-to-filter functionality
- Display tags in glassmorphic tag wall matching site theme
- Only show popular tags (2+ posts) by default to prevent clutter
- Add 'Show all tags' toggle for expanded view
- Display post count for each tag
- Add tags to blog cards with orange accent styling
- Update develop script to bind to 0.0.0.0 for network access

## Changes
- Modified `src/pages/blog.js` to add tag filtering logic and UI
- Updated `src/components/layout.css` with tag wall glassmorphic styles
- Cleaned up `src/components/index.module.css` by removing old tag styles
- Updated `package.json` develop script to use `-H 0.0.0.0` flag